### PR TITLE
TASK 138 voicemail transcription config

### DIFF
--- a/wazo_confd_client/commands/tests/test_voicemail_transcription.py
+++ b/wazo_confd_client/commands/tests/test_voicemail_transcription.py
@@ -1,13 +1,15 @@
 # Copyright 2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from unittest.mock import ANY
-
 from hamcrest import assert_that, equal_to
 
+from wazo_confd_client.session import ConfdSession
 from wazo_confd_client.tests import TestCommand
 
 from ..voicemail_transcription import VoicemailTranscriptionCommand
+
+READ_HEADERS = dict(ConfdSession.READ_HEADERS)
+WRITE_HEADERS = dict(ConfdSession.WRITE_HEADERS)
 
 
 class TestVoicemailTranscription(TestCommand):
@@ -22,18 +24,35 @@ class TestVoicemailTranscription(TestCommand):
         assert_that(result, equal_to(expected))
         self.session.get.assert_called_once_with(
             '/voicemails/transcription',
-            headers=ANY,
+            headers=READ_HEADERS,
             params={},
         )
 
     def test_get_with_tenant_uuid(self):
-        tenant_uuid = 'my-tenant-uuid'
+        self.client.tenant_uuid = None
+        expected_headers = {**READ_HEADERS, 'Wazo-Tenant': 'my-tenant-uuid'}
         self.set_response('get', 200, {'enabled': False})
 
-        self.command.get(tenant_uuid=tenant_uuid)
+        self.command.get(tenant_uuid='my-tenant-uuid')
 
-        call_kwargs = self.session.get.call_args
-        assert_that(call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to(tenant_uuid))
+        self.session.get.assert_called_once_with(
+            '/voicemails/transcription',
+            headers=expected_headers,
+            params={},
+        )
+
+    def test_get_uses_client_tenant_uuid(self):
+        self.client.tenant_uuid = 'client-tenant'
+        expected_headers = {**READ_HEADERS, 'Wazo-Tenant': 'client-tenant'}
+        self.set_response('get', 200, {'enabled': True})
+
+        self.command.get()
+
+        self.session.get.assert_called_once_with(
+            '/voicemails/transcription',
+            headers=expected_headers,
+            params={},
+        )
 
     def test_update(self):
         self.client.tenant_uuid = None
@@ -45,39 +64,36 @@ class TestVoicemailTranscription(TestCommand):
         self.session.put.assert_called_once_with(
             '/voicemails/transcription',
             json=body,
-            headers=ANY,
+            headers=WRITE_HEADERS,
             params={},
         )
 
     def test_update_with_tenant_uuid(self):
-        tenant_uuid = 'my-tenant-uuid'
+        self.client.tenant_uuid = None
+        expected_headers = {**WRITE_HEADERS, 'Wazo-Tenant': 'my-tenant-uuid'}
         self.set_response('put', 204)
         body = {'enabled': True}
 
-        self.command.update(body, tenant_uuid=tenant_uuid)
+        self.command.update(body, tenant_uuid='my-tenant-uuid')
 
-        call_kwargs = self.session.put.call_args
-        assert_that(call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to(tenant_uuid))
-
-    def test_get_uses_client_tenant_uuid(self):
-        self.client.tenant_uuid = 'client-tenant'
-        self.set_response('get', 200, {'enabled': True})
-
-        self.command.get()
-
-        call_kwargs = self.session.get.call_args
-        assert_that(
-            call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to('client-tenant')
+        self.session.put.assert_called_once_with(
+            '/voicemails/transcription',
+            json=body,
+            headers=expected_headers,
+            params={},
         )
 
     def test_update_uses_client_tenant_uuid(self):
         self.client.tenant_uuid = 'client-tenant'
+        expected_headers = {**WRITE_HEADERS, 'Wazo-Tenant': 'client-tenant'}
         self.set_response('put', 204)
         body = {'enabled': True}
 
         self.command.update(body)
 
-        call_kwargs = self.session.put.call_args
-        assert_that(
-            call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to('client-tenant')
+        self.session.put.assert_called_once_with(
+            '/voicemails/transcription',
+            json=body,
+            headers=expected_headers,
+            params={},
         )

--- a/wazo_confd_client/commands/tests/test_voicemail_transcription.py
+++ b/wazo_confd_client/commands/tests/test_voicemail_transcription.py
@@ -14,6 +14,7 @@ class TestVoicemailTranscription(TestCommand):
     Command = VoicemailTranscriptionCommand
 
     def test_get(self):
+        self.client.tenant_uuid = None
         expected = self.set_response('get', 200, {'enabled': True})
 
         result = self.command.get()
@@ -35,6 +36,7 @@ class TestVoicemailTranscription(TestCommand):
         assert_that(call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to(tenant_uuid))
 
     def test_update(self):
+        self.client.tenant_uuid = None
         self.set_response('put', 204)
         body = {'enabled': True}
 
@@ -56,3 +58,26 @@ class TestVoicemailTranscription(TestCommand):
 
         call_kwargs = self.session.put.call_args
         assert_that(call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to(tenant_uuid))
+
+    def test_get_uses_client_tenant_uuid(self):
+        self.client.tenant_uuid = 'client-tenant'
+        self.set_response('get', 200, {'enabled': True})
+
+        self.command.get()
+
+        call_kwargs = self.session.get.call_args
+        assert_that(
+            call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to('client-tenant')
+        )
+
+    def test_update_uses_client_tenant_uuid(self):
+        self.client.tenant_uuid = 'client-tenant'
+        self.set_response('put', 204)
+        body = {'enabled': True}
+
+        self.command.update(body)
+
+        call_kwargs = self.session.put.call_args
+        assert_that(
+            call_kwargs.kwargs['headers']['Wazo-Tenant'], equal_to('client-tenant')
+        )

--- a/wazo_confd_client/commands/voicemail_transcription.py
+++ b/wazo_confd_client/commands/voicemail_transcription.py
@@ -5,27 +5,20 @@ from __future__ import annotations
 
 from typing import Any
 
-from wazo_lib_rest_client import HTTPCommand
-
+from wazo_confd_client.crud import TenantConfigCommand
 from wazo_confd_client.util import url_join
 
 
-class VoicemailTranscriptionCommand(HTTPCommand):
+class VoicemailTranscriptionCommand(TenantConfigCommand):
     resource = 'voicemails/transcription'
 
     def get(self, **kwargs: Any) -> dict[str, Any]:
-        tenant_uuid = kwargs.pop('tenant_uuid', None)
-        headers = dict(self.session.READ_HEADERS)
-        if tenant_uuid:
-            headers['Wazo-Tenant'] = tenant_uuid
+        headers, kwargs = self._get_read_headers(**kwargs)
         url = url_join(self.resource)
         response = self.session.get(url, headers=headers, params=kwargs)
         return response.json()
 
     def update(self, body: dict[str, Any], **kwargs: Any) -> None:
-        tenant_uuid = kwargs.pop('tenant_uuid', None)
-        headers = dict(self.session.WRITE_HEADERS)
-        if tenant_uuid:
-            headers['Wazo-Tenant'] = tenant_uuid
+        headers, kwargs = self._get_write_headers(**kwargs)
         url = url_join(self.resource)
         self.session.put(url, json=body, headers=headers, params=kwargs)

--- a/wazo_confd_client/crud.py
+++ b/wazo_confd_client/crud.py
@@ -1,7 +1,10 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import abc
+from typing import Any
 
 from wazo_lib_rest_client import HTTPCommand
 
@@ -88,3 +91,27 @@ class MultiTenantCommand(CRUDCommand):
         url = url_join(self.resource)
         response = self.session.post(url, body, headers=headers)
         return response.json()
+
+
+class TenantConfigCommand(HTTPCommand):
+    """Base for tenant-scoped singleton config endpoints (get + update)."""
+
+    def _build_tenant_headers(
+        self, base_headers: dict[str, str], tenant_uuid: str | None
+    ) -> dict[str, str]:
+        headers = dict(base_headers)
+        if tenant_uuid:
+            headers['Wazo-Tenant'] = tenant_uuid
+        return headers
+
+    def _get_read_headers(self, **kwargs: Any) -> tuple[dict[str, str], dict[str, Any]]:
+        tenant_uuid = kwargs.pop('tenant_uuid', self._client.tenant_uuid)
+        headers = self._build_tenant_headers(self.session.READ_HEADERS, tenant_uuid)
+        return headers, kwargs
+
+    def _get_write_headers(
+        self, **kwargs: Any
+    ) -> tuple[dict[str, str], dict[str, Any]]:
+        tenant_uuid = kwargs.pop('tenant_uuid', self._client.tenant_uuid)
+        headers = self._build_tenant_headers(self.session.WRITE_HEADERS, tenant_uuid)
+        return headers, kwargs


### PR DESCRIPTION
- **voicemail transcription: added new command**
- **voicemail transcription: extract header logic**
- **voicemail transcription: uniformize tests**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tenant-scoping/header construction for the voicemail transcription config endpoint; a mistake could cause requests to be sent under the wrong tenant. Scope is small and covered by updated unit tests.
> 
> **Overview**
> Refactors the voicemail transcription config command to inherit from a new `TenantConfigCommand`, centralizing how `READ_HEADERS`/`WRITE_HEADERS` and optional `Wazo-Tenant` are applied for singleton `get`/`update` endpoints.
> 
> Updates and expands tests to assert exact headers and to verify tenant resolution precedence (explicit `tenant_uuid` vs `client.tenant_uuid` vs none) for both `get` and `update`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c6ef4cfd3f8911117290b62a0b9fd522b69b841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->